### PR TITLE
[feat] 최신 미팅 리스트 api 

### DIFF
--- a/src/main/java/com/techeersalon/moitda/config/StartConfig.java
+++ b/src/main/java/com/techeersalon/moitda/config/StartConfig.java
@@ -1,0 +1,52 @@
+package com.techeersalon.moitda.config;
+
+import com.techeersalon.moitda.domain.meetings.entity.Meeting;
+import com.techeersalon.moitda.domain.meetings.repository.MeetingRepository;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component // Standard annotation for Spring Boot managed beans
+@Slf4j // Import for logging
+public class StartConfig implements CommandLineRunner {
+
+    @Autowired // Inject MeetingRepository dependency
+    private MeetingRepository meetingRepository;
+
+    @Override
+    @Transactional // Ensure data consistency across multiple saves
+    public void run(String... args) throws Exception {
+        //registerMeeting();
+    }
+
+    private void registerMeeting() {
+        for (int i = 0; i < 105; i++) {
+
+
+            Meeting meeting = Meeting.builder()
+                    .userId(Long.valueOf(i % 15))
+                    .categoryId(Long.valueOf(i % 6))
+                    .title("title" + i)
+                    .participantsCount(1)
+                    .maxParticipantsCount(i % 5)
+                    .address("building" + i)
+                    .buildingName("starbucks" + i)
+                    .approvalRequired(true)
+                    .appointmentTime(LocalDateTime.now().toString())
+                    .build();
+
+            try {
+                meetingRepository.save(meeting);
+                // Log successful save for debugging purposes
+                log.info("Meeting with title '{}' saved successfully.", meeting.getTitle());
+            } catch (Exception e) {
+                // Log error message if save fails
+                log.error("Error saving meeting: {}", e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
@@ -2,15 +2,20 @@ package com.techeersalon.moitda.domain.meetings.controller;
 
 import com.techeersalon.moitda.domain.meetings.dto.request.CreateMeetingRequest;
 import com.techeersalon.moitda.domain.meetings.dto.response.GetMeetingDetailResponse;
+import com.techeersalon.moitda.domain.meetings.entity.Meeting;
 import com.techeersalon.moitda.domain.meetings.service.MeetingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.awt.print.Pageable;
 import java.net.URI;
+import java.util.List;
 
 @Tag(name = "MeetingsController", description = "모임 관련 API")
 @RestController
@@ -31,6 +36,13 @@ public class MeetingsController {
     public ResponseEntity<GetMeetingDetailResponse> meetingDetail(@PathVariable Long meetingId){
         GetMeetingDetailResponse response = meetingService.findMeetingById(meetingId);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "findMeetingsList", description = "모임  조회")
+    @GetMapping("/")
+    public List<Meeting> findMeetingsList(@PageableDefault(sort="createdAt",direction = Sort.Direction.DESC ,size=5) Pageable pageable){
+        List<Meeting> response = meetingService.lastMeetingList(pageable);
+        return response;
     }
     //나중에 MeetingParticipantController로 이동
     @Operation(summary = "addParticipantToMeeting", description = "모임 신청")

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
@@ -1,21 +1,18 @@
 package com.techeersalon.moitda.domain.meetings.controller;
 
 import com.techeersalon.moitda.domain.meetings.dto.request.CreateMeetingRequest;
+import com.techeersalon.moitda.domain.meetings.dto.response.GetLatestMeetingListResponse;
 import com.techeersalon.moitda.domain.meetings.dto.response.GetMeetingDetailResponse;
-import com.techeersalon.moitda.domain.meetings.entity.Meeting;
 import com.techeersalon.moitda.domain.meetings.service.MeetingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.awt.print.Pageable;
 import java.net.URI;
-import java.util.List;
 
 @Tag(name = "MeetingsController", description = "모임 관련 API")
 @RestController
@@ -38,12 +35,13 @@ public class MeetingsController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "findMeetingsList", description = "모임  조회")
-    @GetMapping("/")
-    public List<Meeting> findMeetingsList(@PageableDefault(sort="createdAt",direction = Sort.Direction.DESC ,size=5) Pageable pageable){
-        List<Meeting> response = meetingService.lastMeetingList(pageable);
+    @Operation(summary = "findMeetingsList", description = "모임 조회")
+    @GetMapping("/search/latest")
+    public Page<GetLatestMeetingListResponse> findMeetingsList(@RequestParam(value="page", defaultValue="0")int page){
+        Page<GetLatestMeetingListResponse>  response = meetingService.findMeetings(page);
         return response;
     }
+
     //나중에 MeetingParticipantController로 이동
     @Operation(summary = "addParticipantToMeeting", description = "모임 신청")
     @PostMapping("/{meetingId}")

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/CreateMeetingRequest.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/CreateMeetingRequest.java
@@ -11,8 +11,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Builder
 @NoArgsConstructor
@@ -58,7 +56,7 @@ public class CreateMeetingRequest {
                 .buildingName(buildingName)
                 .maxParticipantsCount(maxParticipantsCount)
                 .approvalRequired(approvalRequired)
-                .appointmentTime(LocalDateTime.parse(appointmentTime))
+                .appointmentTime(appointmentTime)
                 .image(image)
                 .participantsCount(1)
                 .build();

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetLatestMeetingListResponse.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetLatestMeetingListResponse.java
@@ -1,0 +1,39 @@
+package com.techeersalon.moitda.domain.meetings.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.techeersalon.moitda.domain.meetings.entity.Meeting;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GetLatestMeetingListResponse {
+    private Long meetingId;
+
+    private String title;
+
+    private String imageUrl;
+
+    private String address;
+
+    private Integer participantsCount;
+
+    private Integer maxParticipantsCount;
+
+    public static GetLatestMeetingListResponse of(Meeting meeting){
+        return GetLatestMeetingListResponse.builder()
+                .meetingId(meeting.getId())
+                .title(meeting.getTitle())
+                .imageUrl(meeting.getImage())
+                .address(meeting.getAddress())
+                .participantsCount(meeting.getParticipantsCount())
+                .maxParticipantsCount(meeting.getMaxParticipantsCount())
+                .build();
+    }
+}

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
@@ -9,8 +9,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @Builder
@@ -28,7 +26,7 @@ public class Meeting extends BaseEntity {
     @Column(name = "userId", nullable = false)
     private Long userId;
 
-    @Column(name = "categoryId", nullable = false)
+    @Column(name = "categoryId")
     private Long categoryId;
 
     @Column(name = "title",nullable = false)
@@ -37,7 +35,7 @@ public class Meeting extends BaseEntity {
     @Column(name = "participantsCount", nullable = false)
     private Integer participantsCount;
 
-    @Column(name = "max_participantsCount", nullable = false)
+    @Column(name = "maxParticipantsCount", nullable = false)
     private Integer maxParticipantsCount;
 
     @Column(name = "address", nullable = false)
@@ -47,18 +45,18 @@ public class Meeting extends BaseEntity {
     private String buildingName;
 
     @Lob
-    @Column(name = "content", nullable = false)
+    @Column(name = "content")
     private String content;
 
-    @Column(name = "image", length = 256, nullable = false)
+    @Column(name = "image")
     private String image;
 
     @Column(name = "approvalRequired", nullable = false)
     private Boolean approvalRequired;
 
-    @Column(name = "appointmentTime", nullable = false)
-    private LocalDateTime appointmentTime;
+    @Column(name = "appointmentTime")
+    private String appointmentTime;
 
     @Column(name = "endTime")
-    private LocalDateTime endTime;
+    private String endTime;
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingRepository.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingRepository.java
@@ -5,10 +5,13 @@ import com.techeersalon.moitda.domain.meetings.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findByUserId(Long userId);
+    //최신순
+    List<Meeting> findByCreatedAtContains(Pageable pageable);
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingRepository.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingRepository.java
@@ -2,16 +2,18 @@ package com.techeersalon.moitda.domain.meetings.repository;
 
 
 import com.techeersalon.moitda.domain.meetings.entity.Meeting;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Pageable;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 
 @Repository
-public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+public interface MeetingRepository extends PagingAndSortingRepository<Meeting, Long>, JpaRepository<Meeting, Long>{
     List<Meeting> findByUserId(Long userId);
     //최신순
-    List<Meeting> findByCreatedAtContains(Pageable pageable);
+    Page<Meeting> findAll(Pageable pageable);
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 @Service
@@ -67,5 +68,9 @@ public class MeetingService {
     public List<Meeting> getUserMeetingList(){
         Long loginUserId = userService.getLoginUser().getId();
         return meetingRepository.findByUserId(loginUserId);
+    }
+
+    public List<Meeting> lastMeetingList(Pageable pageable) {
+        return meetingRepository.findByCreatedAtContains(pageable);
     }
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -2,6 +2,7 @@
 package com.techeersalon.moitda.domain.meetings.service;
 
 import com.techeersalon.moitda.domain.meetings.dto.request.CreateMeetingRequest;
+import com.techeersalon.moitda.domain.meetings.dto.response.GetLatestMeetingListResponse;
 import com.techeersalon.moitda.domain.meetings.dto.response.GetMeetingDetailResponse;
 import com.techeersalon.moitda.domain.meetings.entity.Meeting;
 import com.techeersalon.moitda.domain.meetings.entity.MeetingParticipant;
@@ -11,11 +12,16 @@ import com.techeersalon.moitda.domain.user.entity.User;
 import com.techeersalon.moitda.domain.user.service.UserService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.print.Pageable;
+import java.util.ArrayList;
 import java.util.List;
+
 
 @Service
 @Transactional
@@ -24,7 +30,7 @@ public class MeetingService {
     private final MeetingRepository meetingRepository;
     private final MeetingParticipantRepository meetingParticipantRepository;
     private final UserService userService;
-
+    private final int pageSize = 32;
     public Long addMeeting(CreateMeetingRequest dto) {
         User loginUser = userService.getLoginUser();
 
@@ -70,7 +76,13 @@ public class MeetingService {
         return meetingRepository.findByUserId(loginUserId);
     }
 
-    public List<Meeting> lastMeetingList(Pageable pageable) {
-        return meetingRepository.findByCreatedAtContains(pageable);
+    public Page<GetLatestMeetingListResponse> findMeetings(int page) {
+        List<Sort.Order> sorts = new ArrayList<>();
+        sorts.add(Sort.Order.desc("createAt"));
+        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(sorts));
+
+        Page<Meeting> meetings = meetingRepository.findAll(pageable);
+
+        return meetings.map(GetLatestMeetingListResponse::of);
     }
 }


### PR DESCRIPTION
### 🚀 Summary

---
최근에 올라온 미팅을 가장 먼저 보여주는 api로 무한 스크롤을 할때 사용된다. 
한 페이지당 32로 했다.
### ✨ Description

<!-- write down the work details and show the execution results. -->
<img width="1042" alt="스크린샷 2024-05-12 오전 4 17 31" src="https://github.com/2024-Team-Techeer-Salon/Moitda-Backend/assets/67044438/00245311-c42d-4bc3-a8a1-3a2c07b3d7ce">

---

### 💩 Issue number
#25 