### PR TITLE
[feat] delete api 삭제 방식 변경

### DIFF
--- a/src/main/java/com/techeersalon/moitda/chat/service/ChatRoomService.java
+++ b/src/main/java/com/techeersalon/moitda/chat/service/ChatRoomService.java
@@ -60,11 +60,11 @@ public class ChatRoomService {
     @Transactional
     public void deleteRoomAndMessages(Long roomId){
         ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElse(null);
-        chatRoom.delete();
+        chatRoomRepository.delete(chatRoom);
+        //chatRoom.delete();
         List<ChatMessage> chatMessageList = chatMessageRepository.findByMeetingId(roomId);
-        for (ChatMessage chatMessage : chatMessageList) {
-            chatMessage.delete();
-        }
+        //chatMessage.delete();
+        chatMessageRepository.deleteAll(chatMessageList);
     }
 
 //    public boolean duplicatedUserChatRoom(Member member) {

--- a/src/main/java/com/techeersalon/moitda/config/StartConfig.java
+++ b/src/main/java/com/techeersalon/moitda/config/StartConfig.java
@@ -14,11 +14,11 @@ import java.time.LocalDateTime;
 @Slf4j // Import for logging
 public class StartConfig implements CommandLineRunner {
 
-    @Autowired // Inject MeetingRepository dependency
+    @Autowired
     private MeetingRepository meetingRepository;
 
     @Override
-    @Transactional // Ensure data consistency across multiple saves
+    @Transactional
     public void run(String... args) throws Exception {
         //registerMeeting();
     }
@@ -34,6 +34,7 @@ public class StartConfig implements CommandLineRunner {
                     .participantsCount(1)
                     .maxParticipantsCount(i % 5)
                     .address("building" + i)
+                    .addressDetail("1 floor")
                     .buildingName("starbucks" + i)
                     .approvalRequired(true)
                     .appointmentTime(LocalDateTime.now().toString())

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE Meeting SET is_deleted = true WHERE meeting_id = ?")
+@SQLDelete(sql = "UPDATE meeting SET is_deleted = true WHERE meeting_id = ?")
 @Where(clause = "is_deleted = false")
 public class Meeting extends BaseEntity {
 
@@ -44,17 +44,17 @@ public class Meeting extends BaseEntity {
     @Column(name = "address", nullable = false)
     private String address;
 
-    @Column(name = "buildingName", nullable = false)
+    @Column(name = "buildingName")
     private String buildingName;
 
-    @Column(name = "addressDetail", nullable = false)
+    @Column(name = "addressDetail")
     private String addressDetail;
 
     @Lob
-    @Column(name = "content", nullable = false)
+    @Column(name = "content")
     private String content;
 
-    @Column(name = "image", length = 256, nullable = false)
+    @Column(name = "image")
     private String image;
 
     @Column(name = "approvalRequired", nullable = false)

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/entity/MeetingParticipant.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/entity/MeetingParticipant.java
@@ -1,18 +1,20 @@
 package com.techeersalon.moitda.domain.meetings.entity;
 
 import com.techeersalon.moitda.global.common.BaseEntity;
-import jakarta.persistence.Entity;
-import lombok.*;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
-import jakarta.persistence.*;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE project SET is_deleted = true WHERE project_id = ?")
+@SQLDelete(sql = "UPDATE meetingParticipant SET is_deleted = true WHERE meeting_participant_id = ?")
 @Where(clause = "is_deleted = false")
 public class MeetingParticipant extends BaseEntity {
     @Id

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/entity/MeetingParticipant.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/entity/MeetingParticipant.java
@@ -14,7 +14,7 @@ import org.hibernate.annotations.Where;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE meetingParticipant SET is_deleted = true WHERE meeting_participant_id = ?")
+@SQLDelete(sql = "UPDATE meeting_participant SET is_deleted = true WHERE meeting_participant_id = ?")
 @Where(clause = "is_deleted = false")
 public class MeetingParticipant extends BaseEntity {
     @Id

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -124,10 +124,8 @@ public class MeetingService {
         Meeting meeting = this.getMeetingById(meetingId);
         List<MeetingParticipant> participantList = meetingParticipantRepository.findByMeetingId(meetingId);
         meetingRepository.delete(meeting);
-        for(MeetingParticipant participant : participantList){
-            meetingParticipantRepository.delete(participant);
-            //meetingParticipantRepository.save(participant);
-        }
+        //meetingParticipantRepository.save(participant);
+        meetingParticipantRepository.deleteAll(participantList);
         //meetingRepository.save(meeting);
     }
 

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -99,15 +99,16 @@ public class MeetingService {
         if (isApproval) {
             participant.notNeedToApprove();
         } else {
-            participant.delete();
+            meetingParticipantRepository.delete(participant);
+            //participant.delete();
         }
-        meetingParticipantRepository.save(participant);
+        //meetingParticipantRepository.save(participant);
     }
 
-    public List<Meeting> getUserMeetingList(){
-        Long loginUserId = userService.getLoginUser().getId();
-        return meetingRepository.findByUserId(loginUserId);
-    }
+//    public List<Meeting> getUserMeetingList(){
+//        Long loginUserId = userService.getLoginUser().getId();
+//        return meetingRepository.findByUserId(loginUserId);
+//    }
 
     public Page<GetLatestMeetingListResponse> findMeetings(int page) {
         List<Sort.Order> sorts = new ArrayList<>();
@@ -122,12 +123,12 @@ public class MeetingService {
     public void deleteMeeting(Long meetingId) {
         Meeting meeting = this.getMeetingById(meetingId);
         List<MeetingParticipant> participantList = meetingParticipantRepository.findByMeetingId(meetingId);
-        meeting.delete();
+        meetingRepository.delete(meeting);
         for(MeetingParticipant participant : participantList){
-            participant.delete();
-            meetingParticipantRepository.save(participant);
+            meetingParticipantRepository.delete(participant);
+            //meetingParticipantRepository.save(participant);
         }
-        meetingRepository.save(meeting);
+        //meetingRepository.save(meeting);
     }
 
     private Meeting getMeetingById(Long meetingId) {

--- a/src/main/java/com/techeersalon/moitda/domain/user/entity/User.java
+++ b/src/main/java/com/techeersalon/moitda/domain/user/entity/User.java
@@ -8,6 +8,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
 
@@ -15,6 +17,8 @@ import java.time.LocalDate;
 @Getter
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE user SET is_deleted = true WHERE user_id = ?")
+@Where(clause = "is_deleted = false")
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/com/techeersalon/moitda/global/common/BaseEntity.java
+++ b/src/main/java/com/techeersalon/moitda/global/common/BaseEntity.java
@@ -4,8 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -23,7 +21,7 @@ public class BaseEntity {
     private LocalDateTime updateAt = LocalDateTime.now();
 
     @Column(name = "is_deleted", nullable = false)
-    private boolean isdeleted = Boolean.FALSE;
+    private Boolean isdeleted = Boolean.FALSE;
 
 //    public void delete() {
 //        this.is_deleted = Boolean.TRUE;

--- a/src/main/java/com/techeersalon/moitda/global/common/BaseEntity.java
+++ b/src/main/java/com/techeersalon/moitda/global/common/BaseEntity.java
@@ -4,12 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Getter
 @MappedSuperclass
@@ -24,7 +25,7 @@ public class BaseEntity {
     @Column(name = "is_deleted", nullable = false)
     private boolean isdeleted = Boolean.FALSE;
 
-    public void delete() {
-        this.isdeleted = Boolean.TRUE;
-    }
+//    public void delete() {
+//        this.is_deleted = Boolean.TRUE;
+//    }
 }

--- a/src/main/java/com/techeersalon/moitda/global/config/SecurityConfig.java
+++ b/src/main/java/com/techeersalon/moitda/global/config/SecurityConfig.java
@@ -67,9 +67,9 @@ public class SecurityConfig {
 //                .authorizeHttpRequests(requests ->
 //                        requests.anyRequest().permitAll() // 모든 요청을 모든 사용자에게 허용
 //                )
-                .authorizeHttpRequests(requests ->
-                        requests.anyRequest().permitAll() // 모든 요청을 모든 사용자에게 허용
-                )
+//                .authorizeHttpRequests(requests ->
+//                        requests.anyRequest().permitAll() // 모든 요청을 모든 사용자에게 허용
+//                )
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(endpoint -> endpoint
                                 .userService(customOAuth2UserService))


### PR DESCRIPTION
### 🚀 Summary

---
issue에서 말한 것 같이 수정 
반복문 사용하지 않고 deleteAll로 해당 데이터들 삭제 가능
### ✨ Description

<!-- write down the work details and show the execution results. -->

---

### 💩 Issue number
#40 