### PR TITLE
[feat] 카테고리 검색 기능 추가, 더미 데이터 생성 수정

### DIFF
--- a/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
@@ -60,11 +60,21 @@ public class MeetingsController {
         return ResponseEntity.ok(SuccessResponse.of(MEETING_GET_SUCCESS, response));
     }
 
-    @Operation(summary = "latestMeetingsList", description = "최신 모임 리스트 조회")
+    @Operation(summary = "latestMeetingsPage", description = "최신 모임 리스트 조회")
     @GetMapping("/search/latest")
-    public ResponseEntity<SuccessResponse> latestMeetingsList(@RequestParam(value="page", defaultValue="0")int page,
+    public ResponseEntity<SuccessResponse> latestMeetingsPage(@RequestParam(value="page", defaultValue="0")int page,
                                                             @RequestParam(value="size", defaultValue="10")int pageSize){
         List<GetLatestMeetingListRes> response = meetingService.latestAllMeetings(page, pageSize);
+
+        return ResponseEntity.ok(SuccessResponse.of(MEETING_PAGING_GET_SUCCESS, response));
+    }
+
+    @Operation(summary = "latestCategoryMeetingsPage", description = "카테고리별 최신 모임 리스트 조회")
+    @GetMapping("/search/latest/{categoryId}")
+    public ResponseEntity<SuccessResponse> latestCategoryMeetingsPage( @PathVariable Long categoryId,
+                                                                       @RequestParam(value="page", defaultValue="0")int page,
+                                                                       @RequestParam(value="size", defaultValue="10")int pageSize){
+        List<GetLatestMeetingListRes> response = meetingService.latestCategoryMeetings(categoryId,page, pageSize);
 
         return ResponseEntity.ok(SuccessResponse.of(MEETING_PAGING_GET_SUCCESS, response));
     }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/CreateMeetingReq.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/CreateMeetingReq.java
@@ -32,7 +32,7 @@ public class CreateMeetingReq {
     @NotBlank(message = "road_address_name cannot be blank")
     private String roadAddressName;
 
-    @NotBlank(message = "detailed_address cannot be blank")
+    //@NotBlank(message = "detailed_address cannot be blank")
     private String detailedAddress;
 
     @NotNull(message = "max_participants_count cannot be blank")

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingRepository.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingRepository.java
@@ -14,8 +14,6 @@ import java.util.Optional;
 
 @Repository
 public interface MeetingRepository extends PagingAndSortingRepository<Meeting, Long>, JpaRepository<Meeting, Long>{
-    List<Meeting> findByUserId(Long userId);
-    //List<Meeting> getUserMeetingList();
 
     //최신순
     Page<Meeting> findAll(Pageable pageable);
@@ -23,4 +21,6 @@ public interface MeetingRepository extends PagingAndSortingRepository<Meeting, L
     Optional<Meeting> findById(Long id);
 
     List<Meeting> findByIdIn(List<Long> ids);
+
+    Page<Meeting> findByCategoryId(Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -249,6 +249,12 @@ public class MeetingService {
         return transformMeetingsToResponse(meetings);
     }
 
+    public List<GetLatestMeetingListRes> latestCategoryMeetings(Long categoryId, int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
+        Page<Meeting> meetings = meetingRepository.findByCategoryId(categoryId, pageable);
+        return transformMeetingsToResponse(meetings);
+    }
+
     private List<GetLatestMeetingListRes> transformMeetingsToResponse(Page<Meeting> meetings) {
         if (meetings.isEmpty()) {
             throw new MeetingPageNotFoundException();

--- a/src/main/java/com/techeersalon/moitda/global/config/InitializeDummyDataConfig.java
+++ b/src/main/java/com/techeersalon/moitda/global/config/InitializeDummyDataConfig.java
@@ -35,8 +35,8 @@ public class InitializeDummyDataConfig implements CommandLineRunner {
     @Override
     @Transactional
     public void run(String... args) throws Exception {
-        //registerUser();
-        //registerMeeting();
+        registerUser();
+        registerMeeting();
     }
 
     private void registerUser(){
@@ -82,9 +82,10 @@ public class InitializeDummyDataConfig implements CommandLineRunner {
         Random random = new Random();
 
         for (int i = 0; i < meetingCount; i++) {
+            User user = userRepository.findById((long) (random.nextInt(6) + 1)).get();
             Meeting meeting = Meeting.builder()
-                    .userId(Long.valueOf(random.nextInt(6) + 1))
-                    .username("name" + (random.nextInt(6) + 1))
+                    .userId(user.getId())
+                    .username(user.getUsername())
                     .categoryId(Long.valueOf(random.nextInt(19)))
                     .title("title" + i)
                     .participantsCount(1)


### PR DESCRIPTION
### 🚀 Summary

---
카테고리 입력 받으면 최신 생성 순서대로 Paging 되어서 나옵니다.

더미데이터 수정
 >-  meeting에 저장된 user의 id와 name이 무작위로 생성된다.

### ✨ Description

<!-- write down the work details and show the execution results. -->

---
#### **카테고리 검색**
> URL : /search/latest/{categoryId} 
> Request Param : page와 pagesize 
> 내용 : catagoryId가 같은 값을 가진 meeting을 Pagination으로 리턴해준다.

핵심코드
![스크린샷 2024-05-22 오전 12 44 46](https://github.com/2024-Team-Techeer-Salon/Moitda-Backend/assets/67044438/a6028da2-1c0f-4afc-8700-390af476371e)

swagger 결과 값
<img width="522" alt="스크린샷 2024-05-22 오전 12 45 51" src="https://github.com/2024-Team-Techeer-Salon/Moitda-Backend/assets/67044438/34d23516-1623-4f6c-bb36-952807b93141">

#### **더미데이터 수정**
>meeting에 저장된 user의 id와 name이 무작위로 생성된다.

핵심코드
<img width="812" alt="스크린샷 2024-05-22 오전 12 49 58" src="https://github.com/2024-Team-Techeer-Salon/Moitda-Backend/assets/67044438/936b1e92-0b4d-4053-a404-c9fde0c6a4de">


### 💩 Issue number
#64 