### PR TITLE
[fix] meeting api dto 수정

### DIFF
--- a/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
@@ -6,10 +6,7 @@ import com.techeersalon.moitda.domain.meetings.dto.request.ApprovalParticipantRe
 import com.techeersalon.moitda.domain.meetings.dto.request.ChangeMeetingInfoReq;
 import com.techeersalon.moitda.domain.meetings.dto.request.CreateMeetingReq;
 import com.techeersalon.moitda.domain.meetings.dto.request.CreateReviewReq;
-import com.techeersalon.moitda.domain.meetings.dto.response.CreateMeetingRes;
-import com.techeersalon.moitda.domain.meetings.dto.response.CreateParticipantRes;
-import com.techeersalon.moitda.domain.meetings.dto.response.GetLatestMeetingListRes;
-import com.techeersalon.moitda.domain.meetings.dto.response.GetMeetingDetailRes;
+import com.techeersalon.moitda.domain.meetings.dto.response.*;
 import com.techeersalon.moitda.domain.meetings.service.MeetingService;
 import com.techeersalon.moitda.global.common.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,10 +68,10 @@ public class MeetingsController {
 
     @Operation(summary = "latestCategoryMeetingsPage", description = "카테고리별 최신 모임 리스트 조회")
     @GetMapping("/search/latest/{categoryId}")
-    public ResponseEntity<SuccessResponse> latestCategoryMeetingsPage( @PathVariable Long categoryId,
-                                                                       @RequestParam(value="page", defaultValue="0")int page,
-                                                                       @RequestParam(value="size", defaultValue="10")int pageSize){
-        List<GetLatestMeetingListRes> response = meetingService.latestCategoryMeetings(categoryId,page, pageSize);
+    public ResponseEntity<SuccessResponse> latestCategoryMeetingsPage(@PathVariable Long categoryId,
+                                                                      @RequestParam(value = "page", defaultValue = "0") int page,
+                                                                      @RequestParam(value = "size", defaultValue = "10") int pageSize) {
+        List<GetLatestMeetingListRes> response = meetingService.latestCategoryMeetings(categoryId, page, pageSize);
 
         return ResponseEntity.ok(SuccessResponse.of(MEETING_PAGING_GET_SUCCESS, response));
     }
@@ -125,5 +122,12 @@ public class MeetingsController {
 
         meetingService.createReview(createReviewReq);
         return ResponseEntity.ok(SuccessResponse.of(REVIEW_CREATE_SUCCESS));
+    }
+
+    @Operation(summary = "getMeetingParticipants", description = "모임 신청자 리스트 조회")
+    @GetMapping("/{meetingId}/participants")
+    public ResponseEntity<SuccessResponse> getMeetingParticipants(@PathVariable Long meetingId) {
+        List<GetParticipantListRes> response = meetingService.getParticipantsOfMeeting(meetingId);
+        return ResponseEntity.ok(SuccessResponse.of(PARTICIPANT_LIST_GET_SUCCESS, response));
     }
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/mapper/MeetingParticipantListMapper.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/mapper/MeetingParticipantListMapper.java
@@ -1,6 +1,7 @@
 package com.techeersalon.moitda.domain.meetings.dto.mapper;
 
 import com.techeersalon.moitda.domain.meetings.entity.MeetingParticipant;
+import com.techeersalon.moitda.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,12 +14,14 @@ import lombok.NoArgsConstructor;
 public class MeetingParticipantListMapper {
     private Long meetingParticipantId;
     private String username;
+    private String profileImage;
 
-    public static MeetingParticipantListMapper from(MeetingParticipant meetingParticipant){
+    public static MeetingParticipantListMapper from(MeetingParticipant meetingParticipant, User user){
 
         return MeetingParticipantListMapper.builder()
                 .meetingParticipantId(meetingParticipant.getId())
                 .username(meetingParticipant.getUsername())
+                .profileImage(user.getProfileImage())
                 .build();
     }
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetMeetingDetailRes.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetMeetingDetailRes.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.techeersalon.moitda.domain.meetings.dto.mapper.MeetingParticipantListMapper;
 import com.techeersalon.moitda.domain.meetings.entity.Meeting;
 import com.techeersalon.moitda.domain.meetings.entity.MeetingImage;
+import com.techeersalon.moitda.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,13 +24,19 @@ public class GetMeetingDetailRes {
 
     private Long userId;
 
+    private String username;
+
+    private String profileImage;
+
+    private Integer mannerStat;
+
     private Long categoryId;
 
     private String content;
 
     private String roadAddressName;
 
-    private String DetailedAddress;
+    private String detailedAddress;
 
     private String placeName;
 
@@ -47,14 +54,18 @@ public class GetMeetingDetailRes {
 
     private Boolean isOwner;
 
-    public static GetMeetingDetailRes of(Meeting meeting, List<MeetingParticipantListMapper> participantList, List<MeetingImage> imageList) {
+    // meeting table에 userId, username을 저장할 필요가 있나요?
+    public static GetMeetingDetailRes of(Meeting meeting, User user, List<MeetingParticipantListMapper> participantList, List<MeetingImage> imageList) {
         return GetMeetingDetailRes.builder()
                 .title(meeting.getTitle())
-                .userId(meeting.getUserId())
+                .userId(meeting.getUserId())    // 필요없으면 주석된 부분 바꿔야함.
+                .username(meeting.getUsername())    //
+                .profileImage(user.getProfileImage())
+                .mannerStat(user.getMannerStat())
                 .categoryId(meeting.getCategoryId())
                 .content(meeting.getContent())
                 .roadAddressName(meeting.getRoadAddressName())
-                .DetailedAddress(meeting.getDetailedAddress())
+                .detailedAddress(meeting.getDetailedAddress())
                 .placeName(meeting.getPlaceName())
                 .maxParticipantsCount(meeting.getMaxParticipantsCount())
                 .participantsCount(meeting.getParticipantsCount())

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetMeetingDetailRes.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetMeetingDetailRes.java
@@ -54,6 +54,8 @@ public class GetMeetingDetailRes {
 
     private Boolean isOwner;
 
+    private String endTime;
+
     // meeting table에 userId, username을 저장할 필요가 있나요?
     public static GetMeetingDetailRes of(Meeting meeting, User user, List<MeetingParticipantListMapper> participantList, List<MeetingImage> imageList) {
         return GetMeetingDetailRes.builder()
@@ -73,6 +75,7 @@ public class GetMeetingDetailRes {
                 .imageList(imageList)
                 .appointmentTime(meeting.getAppointmentTime())
                 .createdAt(meeting.getCreateAt())
+                .endTime(meeting.getEndTime())
                 .build();
     }
 

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetParticipantListRes.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetParticipantListRes.java
@@ -1,0 +1,29 @@
+package com.techeersalon.moitda.domain.meetings.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.techeersalon.moitda.domain.meetings.entity.MeetingParticipant;
+import com.techeersalon.moitda.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GetParticipantListRes {
+    private Long userId;
+    private String username;
+    private String profileImage;
+
+    public static GetParticipantListRes from(User user) {
+        return new GetParticipantListRes(
+                user.getId(),
+                user.getUsername(),
+                user.getProfileImage()
+        );
+    }
+}

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
@@ -53,7 +53,7 @@ public class Meeting extends BaseEntity {
     private String detailedAddress;
 
     @Lob
-    @Column(name = "content")
+    @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "approval_required", nullable = false)
@@ -69,7 +69,7 @@ public class Meeting extends BaseEntity {
         this.participantsCount++;
     }
 
-    public void updateInfo(ChangeMeetingInfoReq dto){
+    public void updateInfo(ChangeMeetingInfoReq dto) {
         this.categoryId = dto.getCategoryId();
         this.title = dto.getTitle();
         this.content = dto.getContent();

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/exception/participant/MeetingParticipantNotFoundException.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/exception/participant/MeetingParticipantNotFoundException.java
@@ -5,6 +5,6 @@ import com.techeersalon.moitda.global.error.exception.BusinessException;
 
 public class MeetingParticipantNotFoundException extends BusinessException {
     public MeetingParticipantNotFoundException(){
-        super(ErrorCode.MEETING_MAX_PARTICIPANTS_NOT_EXCEEDED);
+        super(ErrorCode.PARTICIPANT_NOT_FOUND);
     }
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingParticipantRepository.java
@@ -9,11 +9,9 @@ import java.util.Optional;
 
 @Repository
 public interface MeetingParticipantRepository extends JpaRepository<MeetingParticipant, Long> {
-    Optional<MeetingParticipant> findByMeetingIdAndIsWaiting(Long MeetingId, Boolean bool);
+    List<MeetingParticipant> findByMeetingIdAndIsWaiting(Long MeetingId, Boolean bool);
 
     Boolean existsByMeetingIdAndUserId(Long meetingId, Long UserId);
-
-    List<MeetingParticipant> findByUserIdAndIsWaiting(Long UserId, Boolean bool);
 
     Optional<MeetingParticipant> findByMeetingId(Long Meeting);
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -139,6 +139,8 @@ public class MeetingService {
      * */
     public GetMeetingDetailRes findMeetingById(Long meetingId) {
         Meeting meeting = this.getMeetingById(meetingId);
+        User user = userRepository.findById(meeting.getUserId())
+                .orElseThrow(UserNotFoundException::new);
 
         List<MeetingImage> imageList = meetingImageRepository.findByMeetingId(meetingId);
 
@@ -147,9 +149,13 @@ public class MeetingService {
 
         List<MeetingParticipantListMapper> participantDtoList = participantOptional
                 .stream()
-                .map(MeetingParticipantListMapper::from)
+                .map(participant -> {
+                    User participantUser = userRepository.findById(participant.getUserId())
+                            .orElseThrow(UserNotFoundException::new);
+                    return MeetingParticipantListMapper.from(participant, participantUser);
+                        })
                 .collect(Collectors.toList());
-        return GetMeetingDetailRes.of(meeting, participantDtoList, imageList);
+        return GetMeetingDetailRes.of(meeting, user, participantDtoList, imageList);
     }
 
 //    private MeetingParticipantMapper mapToDto(MeetingParticipant meetingParticipant) {

--- a/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
@@ -5,16 +5,12 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
-import com.techeersalon.moitda.domain.meetings.entity.Meeting;
-import com.techeersalon.moitda.domain.meetings.entity.MeetingImage;
-import com.techeersalon.moitda.domain.meetings.entity.MeetingParticipant;
 import com.techeersalon.moitda.domain.meetings.repository.MeetingImageRepository;
 import com.techeersalon.moitda.domain.meetings.repository.MeetingParticipantRepository;
 import com.techeersalon.moitda.domain.meetings.repository.MeetingRepository;
 import com.techeersalon.moitda.domain.user.dto.mapper.UserMapper;
 import com.techeersalon.moitda.domain.user.dto.request.SignUpReq;
 import com.techeersalon.moitda.domain.user.dto.request.UpdateUserReq;
-import com.techeersalon.moitda.domain.user.dto.response.RecordsRes;
 import com.techeersalon.moitda.domain.user.dto.response.UserProfileRes;
 import com.techeersalon.moitda.domain.user.entity.Role;
 import com.techeersalon.moitda.domain.user.entity.SocialType;
@@ -181,29 +177,5 @@ public class UserService {
 
         return loginUser;
     }
-
-    public RecordsRes getUserMeetingRecords(Long userId) {
-
-        if (userRepository.existsById(userId)) {
-            List<MeetingParticipant> meetingParticipantList =
-                    meetingParticipantRepository.findByUserIdAndIsWaiting(userId, false);
-            List<Long> meetingIds = meetingParticipantList
-                    .stream()
-                    .map(MeetingParticipant::getMeetingId)
-                    .collect(Collectors.toList());
-            List<Meeting> userMeetings = meetingRepository.findByIdIn(meetingIds);
-            // 각 회의에 대한 이미지 가져오기
-            List<List<MeetingImage>> meetingImages = new ArrayList<>();
-            for (Meeting meeting : userMeetings) {
-                List<MeetingImage> meetingImage = meetingImageRepository.findByMeetingId(meeting.getId());
-                meetingImages.add(meetingImage);
-            }
-
-            return userMapper.toUserMeetingRecord(userMeetings, meetingImages);
-        }
-
-        throw new UserNotFoundException();
-    }
-
 
 }

--- a/src/main/java/com/techeersalon/moitda/global/common/SuccessCode.java
+++ b/src/main/java/com/techeersalon/moitda/global/common/SuccessCode.java
@@ -25,6 +25,8 @@ public enum SuccessCode {
     //participant
     PARTICIPANT_CREATE_SUCCESS(HttpStatus.CREATED, "P001", "참가자 생성 성공"),
     PARTICIPANT_APPROVAL_OR_REJECTION_SUCCESS(HttpStatus.NO_CONTENT, "P002", "참가자 승인 또는 거절 성공"),
+    PARTICIPANT_LIST_GET_SUCCESS(HttpStatus.OK, "P003", "모임 신청자 목록 조회"),
+
 
     //review
     REVIEW_CREATE_SUCCESS(HttpStatus.CREATED, "R001", "후기 생성 성공"),


### PR DESCRIPTION
### 🚀 Summary

---
[fix] meeting api dto 수정

### ✨ Description

<!-- write down the work details and show the execution results. -->
content에 대한 저장 가능한 글자가 매우 적어서 다음과 같이 수정.
<img width="500" alt="image" src="https://github.com/2024-Team-Techeer-Salon/Moitda-Backend/assets/88658828/32517bd9-2e21-4136-8be8-7a8106efe628">


GetMeetingDetailRes에 profileImage, mannerStat, endtime 추가.
추가로 참가자 리스트에 프로필 이미지 추가.

그리고 모임 신청자 리스트 조회 기능 추가
<img width="835" alt="image" src="https://github.com/2024-Team-Techeer-Salon/Moitda-Backend/assets/88658828/79917b46-e3b4-4439-b458-fa200c2d9b39">

---
모임 상세조회 dto수정
### 💩 Issue number
