### PR TITLE
[fix] s3 로직 수정

### DIFF
--- a/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
@@ -115,7 +115,6 @@ public class MeetingsController {
     @PatchMapping("/participant")
     public ResponseEntity<SuccessResponse> ApprovalOfMeetingParticipants(@Validated @RequestBody ApprovalParticipantReq dto) {
         meetingService.approvalParticipant(dto);
-
         return ResponseEntity.ok(SuccessResponse.of(PARTICIPANT_APPROVAL_OR_REJECTION_SUCCESS));
     }
 

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetMeetingDetailRes.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetMeetingDetailRes.java
@@ -46,6 +46,8 @@ public class GetMeetingDetailRes {
 
     private List<MeetingParticipantListMapper> participantList;
 
+    private List<MeetingParticipantListMapper> waitingList;
+
     private List<MeetingImage> imageList;
 
     private String appointmentTime;
@@ -59,7 +61,7 @@ public class GetMeetingDetailRes {
     private Boolean approvalRequired;
 
     // meeting table에 userId, username을 저장할 필요가 있나요?
-    public static GetMeetingDetailRes of(Meeting meeting, User user, List<MeetingParticipantListMapper> participantList, List<MeetingImage> imageList) {
+    public static GetMeetingDetailRes of(Meeting meeting, User user, List<MeetingParticipantListMapper> participantList, List<MeetingParticipantListMapper> waitingList, List<MeetingImage> imageList) {
         return GetMeetingDetailRes.builder()
                 .title(meeting.getTitle())
                 .userId(meeting.getUserId())    // 필요없으면 주석된 부분 바꿔야함.
@@ -74,6 +76,7 @@ public class GetMeetingDetailRes {
                 .maxParticipantsCount(meeting.getMaxParticipantsCount())
                 .participantsCount(meeting.getParticipantsCount())
                 .participantList(participantList)
+                .waitingList(waitingList)
                 .imageList(imageList)
                 .appointmentTime(meeting.getAppointmentTime())
                 .createdAt(meeting.getCreateAt())

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetMeetingDetailRes.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetMeetingDetailRes.java
@@ -56,6 +56,8 @@ public class GetMeetingDetailRes {
 
     private String endTime;
 
+    private Boolean approvalRequired;
+
     // meeting table에 userId, username을 저장할 필요가 있나요?
     public static GetMeetingDetailRes of(Meeting meeting, User user, List<MeetingParticipantListMapper> participantList, List<MeetingImage> imageList) {
         return GetMeetingDetailRes.builder()
@@ -76,6 +78,7 @@ public class GetMeetingDetailRes {
                 .appointmentTime(meeting.getAppointmentTime())
                 .createdAt(meeting.getCreateAt())
                 .endTime(meeting.getEndTime())
+                .approvalRequired(meeting.getApprovalRequired())
                 .build();
     }
 

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingParticipantRepository.java
@@ -11,8 +11,6 @@ import java.util.Optional;
 public interface MeetingParticipantRepository extends JpaRepository<MeetingParticipant, Long> {
     List<MeetingParticipant> findByMeetingIdAndIsWaiting(Long MeetingId, Boolean bool);
 
-    List<MeetingParticipant> findParticipantsByMeetingId(Long MeetingId);
-
     Boolean existsByMeetingIdAndUserId(Long meetingId, Long UserId);
 
     Optional<MeetingParticipant> findByMeetingId(Long Meeting);

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -64,9 +64,6 @@ public class MeetingService {
     private final MeetingImageRepository meetingImageRepository;
     private final AmazonS3 amazonS3;
 
-    @Value("${defaultProfileUrl}")
-    private String defaultProfileUrl;
-
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -138,8 +138,10 @@ public class MeetingService {
 
         List<MeetingImage> imageList = meetingImageRepository.findByMeetingId(meetingId);
 
-        List<MeetingParticipant> participants = meetingParticipantRepository.findParticipantsByMeetingId(meetingId);
-        if (participants.isEmpty()) {
+        List<MeetingParticipant> participants = meetingParticipantRepository.findByMeetingIdAndIsWaiting(meetingId, Boolean.FALSE);
+        List<MeetingParticipant> waitingList = meetingParticipantRepository.findByMeetingIdAndIsWaiting(meetingId, Boolean.TRUE);
+
+        if (participants.isEmpty() || waitingList.isEmpty()) {
             throw new MeetingNotFoundException();
         }
 
@@ -151,7 +153,17 @@ public class MeetingService {
                     return MeetingParticipantListMapper.from(participant, participantUser);
                 })
                 .collect(Collectors.toList());
-        return GetMeetingDetailRes.of(meeting, user, participantDtoList, imageList);
+
+        List<MeetingParticipantListMapper> waitingDtoList = waitingList
+                .stream()
+                .map(participant -> {
+                    User participantUser = userRepository.findById(participant.getUserId())
+                            .orElseThrow(UserNotFoundException::new);
+                    return MeetingParticipantListMapper.from(participant, participantUser);
+                })
+                .collect(Collectors.toList());
+
+        return GetMeetingDetailRes.of(meeting, user, participantDtoList, waitingDtoList ,imageList);
     }
 
 //    private MeetingParticipantMapper mapToDto(MeetingParticipant meetingParticipant) {

--- a/src/main/java/com/techeersalon/moitda/domain/user/controller/UserController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/user/controller/UserController.java
@@ -69,11 +69,13 @@ public class UserController {
     @PutMapping(value = "/users", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponse> updateUserProfile(
             @RequestPart @Valid UpdateUserReq updateUserReq,
+            @RequestPart @Valid String profileUrl,
+            @RequestPart @Valid String bannerUrl,
             @RequestPart(name = "profile_image_file", required = false) @Valid MultipartFile profileImageFile,
             @RequestPart(name = "banner_image_file", required = false) @Valid MultipartFile bannerImageFile
     ) throws IOException {
 
-        userService.updateUserProfile(updateUserReq, profileImageFile, bannerImageFile);
+        userService.updateUserProfile(updateUserReq, profileUrl, bannerUrl, profileImageFile, bannerImageFile);
 
         return ResponseEntity.ok(SuccessResponse.of(USER_PROFILE_UPDATE_SUCCESS));
     }

--- a/src/main/java/com/techeersalon/moitda/domain/user/controller/UserController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/user/controller/UserController.java
@@ -69,8 +69,8 @@ public class UserController {
     @PutMapping(value = "/users", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponse> updateUserProfile(
             @RequestPart @Valid UpdateUserReq updateUserReq,
-            @RequestPart @Valid String profileUrl,
-            @RequestPart @Valid String bannerUrl,
+            @RequestPart(required = false) @Valid String profileUrl,
+            @RequestPart(required = false) @Valid String bannerUrl,
             @RequestPart(name = "profile_image_file", required = false) @Valid MultipartFile profileImageFile,
             @RequestPart(name = "banner_image_file", required = false) @Valid MultipartFile bannerImageFile
     ) throws IOException {

--- a/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
@@ -70,15 +70,22 @@ public class UserService {
         return userMapper.toUserProfile(user);
     }
 
-    public void updateUserProfile(UpdateUserReq updateUserReq, MultipartFile profileImage, MultipartFile bannerImage) throws IOException {
+    public void updateUserProfile(UpdateUserReq updateUserReq, String profileUrl, String bannerUrl, MultipartFile profileImage, MultipartFile bannerImage) throws IOException {
         User user = this.getLoginUser();
         String[] urls = new String[2];
 
         // 프로필 이미지 처리
-//        urls[0] = processImage(profileImage, user.getProfileImage(), "user/custom/profile/");
-        urls[0] = processImage(profileImage, "user/custom/profile/");
+        if (profileUrl == null) {
+            urls[0] = processImage(profileImage, "user/custom/profile/");
+        } else {
+            urls[0] = profileUrl;
+        }
         // 배너 이미지 처리
-        urls[1] = processImage(bannerImage, "user/custom/banner/");
+        if (bannerUrl == null) {
+            urls[1] = processImage(bannerImage, "user/custom/banner/");
+        } else {
+            urls[1] = bannerUrl;
+        }
 
         user.updateProfile(updateUserReq, urls[0], urls[1]);
         userRepository.save(user);

--- a/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.techeersalon.moitda.domain.user.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
@@ -114,12 +115,24 @@ public class UserService {
     }
 
     private String processImage(MultipartFile image, String currentImageUrl, String s3Folder, String defaultUrl) throws IOException {
+        // 안들어왔을 경우
         if (image == null) {
             return defaultUrl;
         }
-
+// 기존 상태에선 생각한 이미지 삭제 로직이 확인되지 않음. 기존에 이미지 선택했다가 디폴트로 바꾸는 로직도 x.
         String imageFileName = image.getOriginalFilename();
+        // 기존의 url과 다른 경우 혹은 같은 경우
         if (!currentImageUrl.equals(imageFileName)) {
+            // 기존 파일 s3에서 삭제
+
+            if (currentImageUrl.equals(defaultUrl)) {
+                // db에 저장된 url이 디폴트 값인 경우 (디폴트 url에는 전체 경로가 들어있음)
+                amazonS3.deleteObject(new DeleteObjectRequest(bucketName, currentImageUrl));
+
+            } else {
+                amazonS3.deleteObject(new DeleteObjectRequest(bucketName, s3Folder + currentImageUrl));
+            }
+
             String extension = imageFileName.substring(imageFileName.lastIndexOf(".") + 1);
             String s3FileName = s3Folder + UUID.randomUUID().toString().substring(0, 10) + imageFileName;
 

--- a/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
@@ -97,7 +97,9 @@ public class UserService {
     }
 
     public void updateUserProfile(UpdateUserReq updateUserReq, MultipartFile profileImage, MultipartFile bannerImage) throws IOException {
-        User user = this.getLoginUser();
+        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        User user = userRepository.findBySocialTypeAndEmail(SocialType.valueOf(userDetails.getPassword()), userDetails.getUsername())
+                .orElseThrow(UserNotFoundException::new);
 
         String[] urls = new String[2];
 
@@ -170,6 +172,4 @@ public class UserService {
 
         throw new UserNotFoundException();
     }
-
-
 }

--- a/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/user/service/UserService.java
@@ -35,7 +35,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/techeersalon/moitda/global/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/techeersalon/moitda/global/oauth/OAuth2LoginSuccessHandler.java
@@ -39,7 +39,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                             userRepository.saveAndFlush(user);
                         });
 
-                String redirectUrl = "localhost:3000/?accessToken=" + accessToken + "&refreshToken=" + refreshToken;
+                String redirectUrl = "http://localhost:3000/auth/signup?accessToken=" + accessToken + "&refreshToken=" + refreshToken;
 
                 response.sendRedirect(redirectUrl); // 프론트의 회원가입 추가 정보 입력 폼으로 리다이렉트
 
@@ -52,7 +52,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                             userRepository.saveAndFlush(user);
                         });
 
-                String redirectUrl = "localhost:3000/auth?accessToken=" + accessToken + "&refreshToken=" + refreshToken;
+                String redirectUrl = "http://localhost:3000/auth/login?accessToken=" + accessToken + "&refreshToken=" + refreshToken;
 
                 response.sendRedirect(redirectUrl); // 메인 페이지로 리다이렉트
             }


### PR DESCRIPTION
### 🚀 Summary

---
s3 로직 수정
### ✨ Description

<!-- write down the work details and show the execution results. -->
- 클라이언트에서 url 또는 file 형태로 넘기는 2가지의 경우가 있기 때문에 이에 맞게 로직 수정. 
- 그리고 삭제할 수 있도록 로직 추가.
- baseUrl은 서버측에서 관리하지 않도록 수정.
- 미팅 상세 조회 부분에서 즉시 가입 여부가 필요하기 때문에 이를 추가.
-  participant_list, waiting_list로 나눴음.
<img width="749" alt="image" src="https://github.com/2024-Team-Techeer-Salon/Moitda-Backend/assets/88658828/4bd9ec62-c66b-4982-92a3-a85805c00e0e">

---

### 💩 Issue number
#62