### PR TITLE
[feat] 거리가 가까운 순으로 검색 및 모임 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+	//implementation 'org.hibernate:hibernate-spatial:6.0.Final'
+	implementation 'org.locationtech.jts:jts-core:1.18.2'
+	implementation 'com.querydsl:querydsl-spatial'
+	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '6.4.4.Final'
 	implementation group: 'org.webjars', name: 'stomp-websocket', version: '2.3.3-1'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	//implementation 'org.hibernate:hibernate-spatial:6.0.Final'
 	implementation 'org.locationtech.jts:jts-core:1.18.2'
 	implementation 'com.querydsl:querydsl-spatial'
-	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '6.4.4.Final'
+	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '6.2.7.Final'
 	implementation group: 'org.webjars', name: 'stomp-websocket', version: '2.3.3-1'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
@@ -170,13 +170,13 @@ public class MeetingsController {
         return ResponseEntity.ok(SuccessResponse.of(PARTICIPANT_LIST_GET_SUCCESS, response));
     }
 
-    @Operation(summary = "searchMeetingsByKeyword", description = "키워드로 모임 검색")
-    @GetMapping("/search")
-    public ResponseEntity<SuccessResponse> searchMeetingsByKeyword(
-            @RequestParam(value = "keyword") String keyword,
-            @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size) {
-        List<GetLatestMeetingListRes> response = meetingService.searchMeetingsByKeyword(keyword, page, size);
-        return ResponseEntity.ok(SuccessResponse.of(MEETING_SEARCH_SUCCESS, response));
-    }
+//    @Operation(summary = "searchMeetingsByKeyword", description = "키워드로 모임 검색")
+//    @GetMapping("/search")
+//    public ResponseEntity<SuccessResponse> searchMeetingsByKeyword(
+//            @RequestParam(value = "keyword") String keyword,
+//            @RequestParam(value = "page", defaultValue = "0") int page,
+//            @RequestParam(value = "size", defaultValue = "10") int size) {
+//        List<GetLatestMeetingListRes> response = meetingService.searchMeetingsByKeyword(keyword, page, size);
+//        return ResponseEntity.ok(SuccessResponse.of(MEETING_SEARCH_SUCCESS, response));
+//    }
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
@@ -2,14 +2,15 @@ package com.techeersalon.moitda.domain.meetings.controller;
 
 import com.techeersalon.moitda.domain.chat.entity.ChatRoom;
 import com.techeersalon.moitda.domain.chat.service.ChatRoomService;
+import com.techeersalon.moitda.domain.meetings.dto.mapper.PointMapper;
 import com.techeersalon.moitda.domain.meetings.dto.request.ApprovalParticipantReq;
 import com.techeersalon.moitda.domain.meetings.dto.request.ChangeMeetingInfoReq;
 import com.techeersalon.moitda.domain.meetings.dto.request.CreateMeetingReq;
 import com.techeersalon.moitda.domain.meetings.dto.request.CreateReviewReq;
 import com.techeersalon.moitda.domain.meetings.dto.response.CreateMeetingRes;
 import com.techeersalon.moitda.domain.meetings.dto.response.CreateParticipantRes;
-import com.techeersalon.moitda.domain.meetings.dto.response.GetLatestMeetingListRes;
 import com.techeersalon.moitda.domain.meetings.dto.response.GetMeetingDetailRes;
+import com.techeersalon.moitda.domain.meetings.dto.response.GetSearchPageRes;
 import com.techeersalon.moitda.domain.meetings.service.MeetingService;
 import com.techeersalon.moitda.global.common.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -58,24 +60,50 @@ public class MeetingsController {
         return ResponseEntity.ok(SuccessResponse.of(MEETING_GET_SUCCESS, response));
     }
 
-    @Operation(summary = "latestMeetingsPage", description = "최신 모임 리스트 조회")
-    @GetMapping("/search/latest")
+//    @Operation(summary = "latestMeetingsPage", description = "최신 모임 리스트 조회")
+//    @GetMapping("/search/latest")
+//
+//    public ResponseEntity<SuccessResponse> latestMeetingsList(@RequestParam(value = "page", defaultValue = "0") int page,
+//                                                              @RequestParam(value = "size", defaultValue = "10") int pageSize) {
+//
+//        List<GetLatestMeetingListRes> response = meetingService.latestAllMeetings(page, pageSize);
+//
+//        return ResponseEntity.ok(SuccessResponse.of(MEETING_PAGING_GET_SUCCESS, response));
+//    }
 
-    public ResponseEntity<SuccessResponse> latestMeetingsList(@RequestParam(value = "page", defaultValue = "0") int page,
-                                                              @RequestParam(value = "size", defaultValue = "10") int pageSize) {
+//    @Operation(summary = "latestCategoryMeetingsPage", description = "카테고리별 최신 모임 리스트 조회")
+//    @GetMapping("/search/latest/{categoryId}")
+//    public ResponseEntity<SuccessResponse> latestCategoryMeetingsPage( @PathVariable Long categoryId,
+//                                                                       @RequestParam(value="page", defaultValue="0")int page,
+//                                                                       @RequestParam(value="size", defaultValue="10")int pageSize){
+//        List<GetLatestMeetingListRes> response = meetingService.latestCategoryMeetings(categoryId,page, pageSize);
+//
+//        return ResponseEntity.ok(SuccessResponse.of(MEETING_PAGING_GET_SUCCESS, response));
+//    }
 
-        List<GetLatestMeetingListRes> response = meetingService.latestAllMeetings(page, pageSize);
-
+    @Operation(summary = "NearMeetingsPage", description = "가까운 모임 리스트 조회")
+    @GetMapping("/search/")
+    public ResponseEntity<SuccessResponse> getNearMeetings(
+            @RequestParam double latitude,
+            @RequestParam double longitude,
+            Pageable pageable){
+        PointMapper pointMapper = PointMapper.from(latitude, longitude);
+        //Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
+        GetSearchPageRes response= meetingService.getMeetingsNearLocation(pointMapper, pageable);
         return ResponseEntity.ok(SuccessResponse.of(MEETING_PAGING_GET_SUCCESS, response));
     }
+    //@PageableDefault(sort = "createAt", direction = Sort.Direction.ASC,page = 0, size = 10)Pageable pageable)
 
-    @Operation(summary = "latestCategoryMeetingsPage", description = "카테고리별 최신 모임 리스트 조회")
-    @GetMapping("/search/latest/{categoryId}")
-    public ResponseEntity<SuccessResponse> latestCategoryMeetingsPage( @PathVariable Long categoryId,
-                                                                       @RequestParam(value="page", defaultValue="0")int page,
-                                                                       @RequestParam(value="size", defaultValue="10")int pageSize){
-        List<GetLatestMeetingListRes> response = meetingService.latestCategoryMeetings(categoryId,page, pageSize);
-
+    @Operation(summary = "CategoryNearMeetingsPage", description = "카테고리 모임 리스트 조회")
+    @GetMapping("/search/category/{categoryId}")
+    public ResponseEntity<SuccessResponse> getCategoryMeetings(
+            @PathVariable Long categoryId,
+            @RequestParam double latitude,
+            @RequestParam double longitude,
+            Pageable pageable){
+        PointMapper pointMapper = PointMapper.from(latitude, longitude);
+        //Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
+        GetSearchPageRes response= meetingService.getMeetingsCategory(pointMapper, categoryId,pageable);
         return ResponseEntity.ok(SuccessResponse.of(MEETING_PAGING_GET_SUCCESS, response));
     }
 
@@ -126,4 +154,15 @@ public class MeetingsController {
         meetingService.createReview(createReviewReq);
         return ResponseEntity.ok(SuccessResponse.of(REVIEW_CREATE_SUCCESS));
     }
+
+//    @Operation(summary = "distanceMeetingsPage", description = "범위 모임 리스트 조회")
+//    @GetMapping("/search/distance")
+//    public ResponseEntity<SuccessResponse> distanceMeetingsPage(@RequestParam("latitude") Double latitude, @RequestParam("longitude") Double longitude,
+//                                                                @RequestParam(value="page", defaultValue="0")int page,
+//                                                                @RequestParam(value="size", defaultValue="10")int pageSize){
+//        PointMapper pointMapper = PointMapper.from(latitude, longitude);
+//        List<GetLatestMeetingListRes> response = meetingService.distanceMeetings(pointMapper,page, pageSize);
+//
+//        return ResponseEntity.ok(SuccessResponse.of(MEETING_PAGING_GET_SUCCESS, response));
+//    }
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/mapper/PointMapper.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/mapper/PointMapper.java
@@ -1,0 +1,22 @@
+package com.techeersalon.moitda.domain.meetings.dto.mapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointMapper {
+    private double latitude;
+    private double longitude;
+
+    public static PointMapper from(double latitude, double longitude){
+        return PointMapper.builder()
+                .latitude(latitude)
+                .longitude(longitude)
+                .build();
+    }
+}

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/ChangeMeetingInfoReq.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/ChangeMeetingInfoReq.java
@@ -28,6 +28,10 @@ public class ChangeMeetingInfoReq {
 
     private String detailedAddress;
 
+    double latitude;
+
+    double longitude;
+
     @NotBlank(message = "place_name cannot be blank")
     private String placeName;
 

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/CreateMeetingReq.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/CreateMeetingReq.java
@@ -10,6 +10,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 
 @Getter
 @Builder
@@ -35,6 +38,11 @@ public class CreateMeetingReq {
     //@NotBlank(message = "detailed_address cannot be blank")
     private String detailedAddress;
 
+    //private Point locationPoint;
+    double latitude;
+
+    double longitude;
+
     @NotNull(message = "max_participants_count cannot be blank")
     private Integer maxParticipantsCount;
 
@@ -45,6 +53,9 @@ public class CreateMeetingReq {
     private String appointmentTime;
 
     public Meeting toEntity(User user) {
+        GeometryFactory geometryFactory = new GeometryFactory();
+        Coordinate coord = new Coordinate(longitude, latitude);
+        Point point = geometryFactory.createPoint(coord);
         return Meeting.builder()
                 .userId(user.getId())
                 .username(user.getUsername())
@@ -54,6 +65,7 @@ public class CreateMeetingReq {
                 .roadAddressName(roadAddressName)
                 .placeName(placeName)
                 .detailedAddress(detailedAddress)
+                .locationPoint(point)
                 .maxParticipantsCount(maxParticipantsCount)
                 .approvalRequired(approvalRequired)
                 .appointmentTime(appointmentTime)

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetLatestMeetingListRes.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetLatestMeetingListRes.java
@@ -34,6 +34,10 @@ public class GetLatestMeetingListRes {
 
     private Integer maxParticipantsCount;
 
+    private Double latitude;
+
+    private Double longitude;
+
 
     public static GetLatestMeetingListRes from(Meeting meeting, List<MeetingImage> images){
         String[] roadAddress = meeting.getRoadAddressName().split(" ");
@@ -59,6 +63,8 @@ public class GetLatestMeetingListRes {
                 .roadAddressName(roadAddressName)
                 .participantsCount(meeting.getParticipantsCount())
                 .maxParticipantsCount(meeting.getMaxParticipantsCount())
+                .latitude(meeting.getLocationPoint().getY())
+                .longitude(meeting.getLocationPoint().getX())
                 .build();
     }
 

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetLatestMeetingListRes.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetLatestMeetingListRes.java
@@ -34,6 +34,7 @@ public class GetLatestMeetingListRes {
 
     private Integer maxParticipantsCount;
 
+
     public static GetLatestMeetingListRes from(Meeting meeting, List<MeetingImage> images){
         String[] roadAddress = meeting.getRoadAddressName().split(" ");
         String roadAddressName, url;

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetSearchPageRes.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/response/GetSearchPageRes.java
@@ -1,0 +1,33 @@
+package com.techeersalon.moitda.domain.meetings.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GetSearchPageRes {
+    private List<GetLatestMeetingListRes> meetingList;
+    private int totalPage;
+    private int currentPage;
+    private int totalElements;
+    private int elementsPerPage;
+
+    public static GetSearchPageRes from(List<GetLatestMeetingListRes> meetingList, int totalPage, int currentPage, int totalElements, int elementsPerPage) {
+        return GetSearchPageRes.builder()
+                .meetingList(meetingList)
+                .totalPage(totalPage)
+                .currentPage(currentPage)
+                .totalElements(totalElements)
+                .elementsPerPage(elementsPerPage)
+                .build();
+    }
+}

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import org.locationtech.jts.geom.Point;
 
 @Entity
 @Getter
@@ -51,6 +52,10 @@ public class Meeting extends BaseEntity {
 
     @Column(name = "detailed_address")
     private String detailedAddress;
+
+    @Column(name = "location_point", columnDefinition = "GEOMETRY")
+    //@Type(type = "org.hibernate.spatial.")
+    private Point locationPoint;
 
     @Lob
     @Column(name = "content")

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/entity/Meeting.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 
 @Entity
@@ -53,8 +55,8 @@ public class Meeting extends BaseEntity {
     @Column(name = "detailed_address")
     private String detailedAddress;
 
-    @Column(name = "location_point", columnDefinition = "GEOMETRY")
-    //@Type(type = "org.hibernate.spatial.")
+    @Column(name = "location_point")
+    //@Type(org.hibernate.spatial.)
     private Point locationPoint;
 
     @Lob
@@ -75,12 +77,17 @@ public class Meeting extends BaseEntity {
     }
 
     public void updateInfo(ChangeMeetingInfoReq dto){
+        GeometryFactory geometryFactory = new GeometryFactory();
+        Coordinate coord = new Coordinate(dto.getLongitude(), dto.getLatitude());
+        Point point = geometryFactory.createPoint(coord);
+
         this.categoryId = dto.getCategoryId();
         this.title = dto.getTitle();
         this.content = dto.getContent();
         this.placeName = dto.getPlaceName();
         this.roadAddressName = dto.getRoadAddressName();
         this.detailedAddress = dto.getDetailedAddress();
+        this.locationPoint = point;
         this.maxParticipantsCount = dto.getMaxParticipantsCount();
         this.appointmentTime = dto.getAppointmentTime();
     }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingRepository.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingRepository.java
@@ -2,11 +2,14 @@ package com.techeersalon.moitda.domain.meetings.repository;
 
 
 import com.techeersalon.moitda.domain.meetings.entity.Meeting;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,4 +26,19 @@ public interface MeetingRepository extends PagingAndSortingRepository<Meeting, L
     List<Meeting> findByIdIn(List<Long> ids);
 
     Page<Meeting> findByCategoryId(Long categoryId, Pageable pageable);
+
+
+//    @Query(value = "SELECT * FROM meeting WHERE ST_Distance_Sphere(location_point, :point) <= 1000",
+//            nativeQuery = true)
+//    Page<Meeting> findMeetingByDistance(@Param("point") Point point, Pageable pageable);
+
+    @Query(value = "SELECT * FROM meeting ORDER BY ST_Distance_Sphere(location_point, :point)",
+            countQuery = "SELECT count(*) FROM meeting",
+            nativeQuery = true)
+    Page<Meeting> findByLocationNear(@Param("point") Point point, Pageable pageable);
+
+    @Query(value = "SELECT * FROM meeting WHERE Category_id = :category ORDER BY ST_Distance_Sphere(location_point, :point) ",
+            countQuery = "SELECT count(*) FROM meeting WHERE Category_id = :category",
+            nativeQuery = true)
+    Page<Meeting> findByLocationNearAndCategory(@Param("point") Point point, @Param("category") Long category, Pageable pageable);
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -424,11 +424,11 @@ public class MeetingService {
                 .collect(Collectors.toList());
     }
 
-    public List<GetLatestMeetingListRes> searchMeetingsByKeyword(String keyword, int page, int pageSize) {
-        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
-        Page<Meeting> meetings = meetingRepository.findByKeyword(keyword, pageable);
-        return transformMeetingsToResponse(meetings);
-    }
+//    public List<GetLatestMeetingListRes> searchMeetingsByKeyword(String keyword, int page, int pageSize) {
+//        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
+//        Page<Meeting> meetings = meetingRepository.findByKeyword(keyword, pageable);
+//        return transformMeetingsToResponse(meetings);
+//    }
 
 
 

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/service/MeetingService.java
@@ -8,11 +8,12 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
 import com.techeersalon.moitda.domain.meetings.dto.mapper.MeetingParticipantListMapper;
 import com.techeersalon.moitda.domain.meetings.dto.mapper.MeetingParticipantMapper;
-import com.techeersalon.moitda.domain.meetings.dto.request.*;
-import com.techeersalon.moitda.domain.meetings.dto.response.CreateMeetingRes;
-import com.techeersalon.moitda.domain.meetings.dto.response.CreateParticipantRes;
-import com.techeersalon.moitda.domain.meetings.dto.response.GetLatestMeetingListRes;
-import com.techeersalon.moitda.domain.meetings.dto.response.GetMeetingDetailRes;
+import com.techeersalon.moitda.domain.meetings.dto.mapper.PointMapper;
+import com.techeersalon.moitda.domain.meetings.dto.request.ApprovalParticipantReq;
+import com.techeersalon.moitda.domain.meetings.dto.request.ChangeMeetingInfoReq;
+import com.techeersalon.moitda.domain.meetings.dto.request.CreateMeetingReq;
+import com.techeersalon.moitda.domain.meetings.dto.request.CreateReviewReq;
+import com.techeersalon.moitda.domain.meetings.dto.response.*;
 import com.techeersalon.moitda.domain.meetings.entity.Meeting;
 import com.techeersalon.moitda.domain.meetings.entity.MeetingImage;
 import com.techeersalon.moitda.domain.meetings.entity.MeetingParticipant;
@@ -35,11 +36,12 @@ import com.techeersalon.moitda.global.s3.exception.S3Exception;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -240,34 +242,56 @@ public class MeetingService {
      * 미팅 리스트 조회 메소드
      * 간략화 된 미팅 내용을 최대 32개인 한 페이지로 준다.
      * */
-    public List<GetLatestMeetingListRes> latestAllMeetings(int page, int pageSize) {
-        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
-        Page<Meeting> meetings = meetingRepository.findAll(pageable);
-        return transformMeetingsToResponse(meetings);
-    }
-
-    public List<GetLatestMeetingListRes> latestUserRecordMeetings(Long userId, int page, int pageSize) {
-        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
+//    public List<GetLatestMeetingListRes> latestAllMeetings(int page, int pageSize) {
+//        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
+//        Page<Meeting> meetings = meetingRepository.findAll(pageable);
+//        return transformMeetingsToResponse(meetings);
+//    }
+//
+    public GetSearchPageRes latestUserRecordMeetings(Long userId, Pageable pageable) {
+        //Pageable pageable = PageRequest.of(pageable, Sort.by(Sort.Order.desc("createAt")));
         Page<Meeting> meetings = meetingRepository.findByUserId(userId, pageable);
         return transformMeetingsToResponse(meetings);
     }
-
-    public List<GetLatestMeetingListRes> latestCategoryMeetings(Long categoryId, int page, int pageSize) {
-        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
-        Page<Meeting> meetings = meetingRepository.findByCategoryId(categoryId, pageable);
+//
+//    public List<GetLatestMeetingListRes> latestCategoryMeetings(Long categoryId, int page, int pageSize) {
+//        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
+//        Page<Meeting> meetings = meetingRepository.findByCategoryId(categoryId, pageable);
+//        return transformMeetingsToResponse(meetings);
+//    }
+//
+//    public List<GetLatestMeetingListRes> distanceMeetings(PointMapper point, int page, int pageSize) {
+//        Point p = mappingPoint(point);
+//        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
+//        List<Meeting> meetings = meetingRepository.findMeetingByDistance(p, pageable).stream().toList();
+//        return transformMeetingsToResponse(meetings);
+//    }
+//
+//
+    public GetSearchPageRes getMeetingsNearLocation(PointMapper pointMapper, Pageable pageable) {
+        Point point = mappingPoint(pointMapper);
+        Page<Meeting> meetings = meetingRepository.findByLocationNear(point, pageable);
         return transformMeetingsToResponse(meetings);
     }
 
-    private List<GetLatestMeetingListRes> transformMeetingsToResponse(Page<Meeting> meetings) {
+    public GetSearchPageRes getMeetingsCategory (PointMapper pointMapper, Long categoryId,Pageable pageable) {
+        Point point = mappingPoint(pointMapper);
+        Page<Meeting> meetings = meetingRepository.findByLocationNearAndCategory(point, categoryId, pageable);
+        return transformMeetingsToResponse(meetings);
+    }
+
+    private GetSearchPageRes transformMeetingsToResponse(Page<Meeting> meetings) {
         if (meetings.isEmpty()) {
             throw new MeetingPageNotFoundException();
         }
-        return meetings.stream()
+        List<GetLatestMeetingListRes> meetingList = meetings.stream()
                 .map(meeting -> {
                     List<MeetingImage> images = meetingImageRepository.findByMeetingId(meeting.getId());
                     return GetLatestMeetingListRes.from(meeting, images);
                 })
                 .collect(Collectors.toList());
+
+        return GetSearchPageRes.from(meetingList, meetings.getTotalPages(), meetings.getNumber(), (int) meetings.getTotalElements(), meetings.getSize());
     }
 
 
@@ -415,4 +439,15 @@ public class MeetingService {
 
         return Math.max(Math.min(existingMannerStat + adjustment, 100), 0);
     }
+
+
+
+    private Point mappingPoint(PointMapper pointMapper){
+        GeometryFactory geometryFactory = new GeometryFactory();
+        Coordinate coord = new Coordinate(pointMapper.getLongitude(), pointMapper.getLatitude());
+        Point point = geometryFactory.createPoint(coord);
+        return point;
+    }
+
+
 }

--- a/src/main/java/com/techeersalon/moitda/domain/user/controller/UserController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.techeersalon.moitda.domain.user.controller;
 
-import com.techeersalon.moitda.domain.meetings.dto.response.GetLatestMeetingListRes;
+import com.techeersalon.moitda.domain.meetings.dto.response.GetSearchPageRes;
 import com.techeersalon.moitda.domain.meetings.service.MeetingService;
 import com.techeersalon.moitda.domain.user.dto.request.SignUpReq;
 import com.techeersalon.moitda.domain.user.dto.request.UpdateUserReq;
@@ -11,13 +11,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
 
 import static com.techeersalon.moitda.global.common.SuccessCode.*;
 
@@ -73,9 +75,10 @@ public class UserController {
     @GetMapping("/users/{user_id}/records")
     public ResponseEntity<SuccessResponse> getUserMeetingRecords(@PathVariable("user_id") Long userId,
                                                                  @RequestParam(value = "page", defaultValue = "0") int page,
-                                                                 @RequestParam(value = "size", defaultValue = "10") int pageSize) {
+                                                                 @RequestParam(value = "size", defaultValue = "10") int pageSize){
+        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("createAt")));
 
-        List<GetLatestMeetingListRes> meetingRecords = meetingService.latestUserRecordMeetings(userId, page, pageSize);
+        GetSearchPageRes meetingRecords = meetingService.latestUserRecordMeetings(userId, pageable);
 
         return ResponseEntity.ok(SuccessResponse.of(USER_MEETING_RECORD_GET_SUCCESS, meetingRecords));
     }

--- a/src/main/java/com/techeersalon/moitda/global/config/InitializeDummyDataConfig.java
+++ b/src/main/java/com/techeersalon/moitda/global/config/InitializeDummyDataConfig.java
@@ -35,8 +35,8 @@ public class InitializeDummyDataConfig implements CommandLineRunner {
     @Override
     @Transactional
     public void run(String... args) throws Exception {
-        //registerUser();
-        //registerMeeting();
+//        registerUser();
+//        registerMeeting();
     }
 
     private void registerUser(){


### PR DESCRIPTION
### 🚀 Summary

---
- 기준 포인트로 부터 가까운 모임 조회 
- 거리 기준 특정 카테고리 모임 조회
- 모임 생성, 수정, 조회 등 경위도 추가
- 모임 리스트 조회시 page info와 경위도 추가 전송
### ✨ Description

<!-- write down the work details and show the execution results. -->

---
<img width="724" alt="스크린샷 2024-05-26 오후 4 08 01" src="https://github.com/2024-Team-Techeer-Salon/Moitda-Backend/assets/67044438/7f2d40d3-8ded-4a88-8ac4-7dcb67e8bc21">

**1. 기준 포인트로 부터 가까운 모임 조회**

**URL**
http://localhost:8080/api/v1/meetings/search/?latitude=위도&longitude=경도&page=현재 페이지&size=페이지에 들어가는 데이터 수 &sort=정렬 조건 
정렬 조건 예시 : create_at,asc
정렬은 거리가 같은 값이 존재하면 순서를 정해주는 것입니다.

**RESPONSE**
<img width="606" alt="스크린샷 2024-05-26 오후 4 12 53" src="https://github.com/2024-Team-Techeer-Salon/Moitda-Backend/assets/67044438/0dbf6816-100d-4b32-86f0-a073f49d003d">

### 💩 Issue

 number
#71 