### PR TITLE
[feat] meetingService 수정

### DIFF
--- a/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/controller/MeetingsController.java
@@ -151,7 +151,7 @@ public class MeetingsController {
     }
 
     @Operation(summary = "reviewParticipants", description = "후기 작성")
-    @PostMapping("reviews")
+    @PostMapping("/reviews")
     public ResponseEntity<SuccessResponse> createReview(@RequestBody @Valid CreateReviewReq createReviewReq) {
 
         meetingService.createReview(createReviewReq);
@@ -176,5 +176,10 @@ public class MeetingsController {
         return ResponseEntity.ok(SuccessResponse.of(PARTICIPANT_LIST_GET_SUCCESS, response));
     }
 
-
+    @Operation(summary = "hasReviewedMeeting", description = "사용자가 특정 모임에 대해 리뷰를 작성했는지 여부 확인")
+    @GetMapping("/reviews/{meetingId}")
+    public ResponseEntity<SuccessResponse> hasReviewedMeeting(@PathVariable Long meetingId) {
+        boolean hasReviewed = meetingService.hasReviewedMeeting(meetingId);
+        return ResponseEntity.ok(SuccessResponse.of(REVIEW_STATUS_SUCCESS, hasReviewed));
+    }
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/mapper/MeetingParticipantListMapper.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/mapper/MeetingParticipantListMapper.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MeetingParticipantListMapper {
-    private Long meetingParticipantId;
+    private Long userId;
     private String username;
     private String profileImage;
     private Boolean isWaiting;
@@ -20,7 +20,7 @@ public class MeetingParticipantListMapper {
     public static MeetingParticipantListMapper from(MeetingParticipant meetingParticipant, User user) {
 
         return MeetingParticipantListMapper.builder()
-                .meetingParticipantId(meetingParticipant.getId())
+                .userId(meetingParticipant.getUserId())
                 .username(meetingParticipant.getUsername())
                 .profileImage(user.getProfileImage())
                 .isWaiting(meetingParticipant.getIsWaiting())

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/mapper/MeetingParticipantMapper.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/mapper/MeetingParticipantMapper.java
@@ -21,6 +21,7 @@ public class MeetingParticipantMapper {
                 .userId(meeting.getUserId())
                 .username(meeting.getUsername())
                 .isWaiting(Boolean.TRUE)
+                .isReviewed(Boolean.FALSE)
                 .build();
     }
 
@@ -30,6 +31,7 @@ public class MeetingParticipantMapper {
                 .userId(user.getId())
                 .username(user.getUsername())
                 .isWaiting(Boolean.TRUE)
+                .isReviewed(Boolean.FALSE)
                 .build();
     }
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/CreateMeetingReq.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/dto/request/CreateMeetingReq.java
@@ -73,5 +73,4 @@ public class CreateMeetingReq {
                 .build();
     }
 
-    // 초기 데이터 생성용 생성자
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/entity/MeetingParticipant.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/entity/MeetingParticipant.java
@@ -34,7 +34,14 @@ public class MeetingParticipant extends BaseEntity {
     @Column(name = "is_waiting", nullable = false)
     private Boolean isWaiting;
 
+    @Column(name = "is_reviewed", nullable = false)
+    private Boolean isReviewed;
+
     public void notNeedToApprove() {
         this.isWaiting = false;
+    }
+
+    public void updateReviewed() {
+        this.isReviewed = true;
     }
 }

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/exception/review/AlreadyReviewedException.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/exception/review/AlreadyReviewedException.java
@@ -1,0 +1,10 @@
+package com.techeersalon.moitda.domain.meetings.exception.review;
+
+import com.techeersalon.moitda.global.error.ErrorCode;
+import com.techeersalon.moitda.global.error.exception.BusinessException;
+
+public class AlreadyReviewedException extends BusinessException {
+    public AlreadyReviewedException() {
+        super(ErrorCode.ALREADY_REVIEWED);
+    }
+}

--- a/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/techeersalon/moitda/domain/meetings/repository/MeetingParticipantRepository.java
@@ -14,4 +14,6 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
     Boolean existsByMeetingIdAndUserId(Long meetingId, Long UserId);
 
     Optional<MeetingParticipant> findByMeetingId(Long Meeting);
+
+    MeetingParticipant findByMeetingIdAndUserId(Long meetingId, Long userId);
 }

--- a/src/main/java/com/techeersalon/moitda/global/common/SuccessCode.java
+++ b/src/main/java/com/techeersalon/moitda/global/common/SuccessCode.java
@@ -40,6 +40,7 @@ public enum SuccessCode {
     USER_APPROVAL_SUCCESS(HttpStatus.OK,"CR002", "유저 채팅방 가입 성공"),
     //review
     REVIEW_CREATE_SUCCESS(HttpStatus.CREATED, "R001", "후기 생성 성공"),
+    REVIEW_STATUS_SUCCESS(HttpStatus.OK, "R002", "리뷰 참여 여부 조회 성공"),
 
     ;
     private HttpStatus status;

--- a/src/main/java/com/techeersalon/moitda/global/error/ErrorCode.java
+++ b/src/main/java/com/techeersalon/moitda/global/error/ErrorCode.java
@@ -33,8 +33,10 @@ public enum ErrorCode {
     // 채팅방
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"CR001","채팅방을 찾을 수 없습니다."),
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"CM001","메시지를 찾을 수 없습니다"),
+
     // 평가
     INVALID_RATING_SCORE(HttpStatus.BAD_REQUEST, "R001", "평가 점수는 1부터 5까지만 가능합니다."),
+    ALREADY_REVIEWED(HttpStatus.BAD_REQUEST, "R002", "이미 리뷰를 마쳤습니다.")
 
     ;
 


### PR DESCRIPTION
### 🚀 Summary

---
meetingService 수정
### ✨ Description

<!-- write down the work details and show the execution results. -->

---
-모임 상세조회 시 participant_list안에 userId가 들어가도록 수정.

-파라미터로 meetingId를 넣으면 사용자가 모임에 대한 리뷰를 했는지 여부를 반환하도록 하는 api 추가.
### 💩 Issue number
#119 